### PR TITLE
Ensure display link registers for notifications

### DIFF
--- a/CustomHUDDemo/CustomHUD/CustomDrawPathView/CustomDisplayLink.swift
+++ b/CustomHUDDemo/CustomHUD/CustomDrawPathView/CustomDisplayLink.swift
@@ -83,5 +83,6 @@ class CustomDisplayLink: NSObject {
     override init() {
         super.init()
         self.setupDisplayLink()
+        self.setupNotificationCenter()
     }
 }


### PR DESCRIPTION
## Summary
- wire up notification monitoring when `CustomDisplayLink` is created

## Testing
- `xcodebuild -list -project CustomHUDDemo.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510b9df01083248d8cb3e6eae90714