### PR TITLE
Add test for hex color initializer

### DIFF
--- a/CustomHUDDemoTests/CustomHUDDemoTests.swift
+++ b/CustomHUDDemoTests/CustomHUDDemoTests.swift
@@ -14,4 +14,9 @@ struct CustomHUDDemoTests {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
 
+    @Test func testNetHexInitializer() async throws {
+        let color = UIColor(netHex: 0xFF0000)
+        #expect(color == UIColor(red: 1, green: 0, blue: 0, alpha: 1))
+    }
+
 }


### PR DESCRIPTION
## Summary
- add a unit test verifying `UIColor(netHex:)`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68510bcea04483249e8e0f860994fa05