### PR TITLE
Add HUD unit and UI tests

### DIFF
--- a/CustomHUDDemoTests/CustomHUDDemoTests.swift
+++ b/CustomHUDDemoTests/CustomHUDDemoTests.swift
@@ -14,9 +14,25 @@ struct CustomHUDDemoTests {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
 
-    @Test func testNetHexInitializer() async throws {
-        let color = UIColor(netHex: 0xFF0000)
-        #expect(color == UIColor(red: 1, green: 0, blue: 0, alpha: 1))
-    }
+  @Test func testNetHexInitializer() async throws {
+      let color = UIColor(netHex: 0xFF0000)
+      #expect(color == UIColor(red: 1, green: 0, blue: 0, alpha: 1))
+  }
+
+  @Test func testCreateMutableString() async throws {
+      let message = "Hello"
+      let attr = CustomHUD.createMutableString(message: message)
+      #expect(attr?.string == message)
+      let attributes = attr?.attributes(at: 0, effectiveRange: nil)
+      let color = attributes?[.foregroundColor] as? UIColor
+      let font = attributes?[.font] as? UIFont
+      #expect(color == UIColor(red: 0.5098039216, green: 0.5098039216, blue: 0.5098039216, alpha: 1))
+      #expect(font?.pointSize == 16)
+  }
+
+  @Test func testCreateMutableStringNil() async throws {
+      let attr = CustomHUD.createMutableString(message: nil)
+      #expect(attr == nil)
+  }
 
 }

--- a/CustomHUDDemoUITests/CustomHUDDemoUITests.swift
+++ b/CustomHUDDemoUITests/CustomHUDDemoUITests.swift
@@ -40,4 +40,35 @@ final class CustomHUDDemoUITests: XCTestCase {
             }
         }
     }
+
+    @MainActor
+    func testHUDFlow() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let loadButton = app.buttons["顯示 LoadView"]
+        XCTAssertTrue(loadButton.exists)
+        loadButton.tap()
+
+        let loadingText = app.staticTexts["加載中"]
+        XCTAssertTrue(loadingText.waitForExistence(timeout: 2))
+
+        let notExist = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: notExist, object: loadingText)
+        _ = XCTWaiter.wait(for: [expectation], timeout: 5)
+
+        let successButton = app.buttons["顯示成功"]
+        XCTAssertTrue(successButton.exists)
+        successButton.tap()
+        XCTAssertTrue(app.windows.count > 1)
+        sleep(2)
+        XCTAssertTrue(app.windows.count == 1)
+
+        let failButton = app.buttons["顯示失敗"]
+        XCTAssertTrue(failButton.exists)
+        failButton.tap()
+        XCTAssertTrue(app.windows.count > 1)
+        sleep(2)
+        XCTAssertTrue(app.windows.count == 1)
+    }
 }


### PR DESCRIPTION
## Summary
- extend unit tests to cover `createMutableString`
- add UI test covering loading, success, and failure flows

## Testing
- `xcodebuild -scheme CustomHUDDemo -testPlan Default` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510d95f1308324af3502ed9853ec30